### PR TITLE
[WIP] Adapted to ES 2+ (tested on ES 2.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,15 @@ notifications:
     on_failure: always
   irc: "irc.perl.org#metacpan-travis"
 
+env:
+  - ES_VERSION=2.3.1
+
 before_install:
   - cpanm -n Devel::Cover::Report::Coveralls
   - cpanm -n Carton
+  - "mkdir /tmp/elasticsearch"
+  - "wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1"
+  - "/tmp/elasticsearch/bin/elasticsearch -d -D es.path.data=/tmp -D es.index.store.type=memory -D es.discovery.zen.ping.multicast.enabled=false -D es.http.port=9900 -D es.cluster.name=testing"
 
 install:
   - 'carton install'
@@ -30,6 +36,3 @@ script:
 
 after_success:
   - cover -report coveralls
-
-services:
-  - elasticsearch

--- a/lib/ElasticSearchX/Model/Document/Mapping.pm
+++ b/lib/ElasticSearchX/Model/Document/Mapping.pm
@@ -185,7 +185,6 @@ sub _set_doc_values {
     if ( $mapping{type} eq 'string'
         && ( $mapping{index} || 'analyzed' ) eq 'analyzed' )
     {
-        $mapping{fielddata} = { format => 'disabled' };
         delete $mapping{doc_values};
     }
     elsif ( $mapping{type} eq 'multi_field' ) {

--- a/lib/ElasticSearchX/Model/Document/Mapping.pm
+++ b/lib/ElasticSearchX/Model/Document/Mapping.pm
@@ -55,7 +55,6 @@ $MAPPING{Str} = sub {
                     $attr->not_analyzed
                     ? (
                         $attr->name => {
-#                            store        => $attr->store,
                             index        => 'not_analyzed',
                             ignore_above => 2048,
                             doc_values   => \1,
@@ -73,7 +72,6 @@ $MAPPING{Str} = sub {
                     index => 'analyzed',
                     $attr->boost ? ( boost => $attr->boost ) : (),
                     type      => $attr->type,
-#                    fielddata => { format => 'disabled' },
                     %term,
                     analyzer => shift @analyzer
                 },
@@ -84,7 +82,6 @@ $MAPPING{Str} = sub {
                             index => 'analyzed',
                             $attr->boost ? ( boost => $attr->boost ) : (),
                             type      => $attr->type,
-#                            fielddata => { format => 'disabled' },
                             %term,
                             analyzer => $_
                         }

--- a/lib/ElasticSearchX/Model/Document/Mapping.pm
+++ b/lib/ElasticSearchX/Model/Document/Mapping.pm
@@ -186,6 +186,9 @@ sub _set_doc_values {
         $mapping{fielddata} = { format => 'disabled' };
         delete $mapping{doc_values};
     }
+    elsif ( $mapping{type} eq 'multi_field' ) {
+        delete $mapping{fielddata};
+    }
     else {
         $mapping{doc_values} = \1;
         delete $mapping{fielddata};

--- a/lib/ElasticSearchX/Model/Document/Mapping.pm
+++ b/lib/ElasticSearchX/Model/Document/Mapping.pm
@@ -18,10 +18,11 @@ sub maptc {
     elsif ($sub) {
         %ret = $sub->( $attr, $constraint );
     }
-    # the below fix may not be complete because of type 'object' with nested structures
+
     if ( $ret{type} ne 'string' ) {
         delete $ret{ignore_above};
     }
+
     return %ret;
 }
 
@@ -70,18 +71,20 @@ $MAPPING{Str} = sub {
                 analyzed => {
                     store => $attr->store,
                     index => 'analyzed',
+                    type  => $attr->type,
                     $attr->boost ? ( boost => $attr->boost ) : (),
-                    type      => $attr->type,
                     %term,
-                    analyzer => shift @analyzer
+                    analyzer => shift @analyzer,
+                    $attr->type eq 'string'
+                    ? ( fielddata => { format => 'disabled' } ) : (),
                 },
                 (
                     map {
                         $_ => {
                             store => $attr->store,
                             index => 'analyzed',
+                            type  => $attr->type,
                             $attr->boost ? ( boost => $attr->boost ) : (),
-                            type      => $attr->type,
                             %term,
                             analyzer => $_
                         }

--- a/lib/ElasticSearchX/Model/Document/Types.pm
+++ b/lib/ElasticSearchX/Model/Document/Types.pm
@@ -40,15 +40,14 @@ subtype TimestampField,
     as Dict [
     enabled => Bool,
     path    => Optional [Str],
-    store   => Optional [Bool],
     index   => Optional [Str],
     slurpy HashRef,
     ];
 coerce TimestampField, from Int, via {
-    { enabled => 1, store => 1 };
+    { enabled => 1 };
 };
 coerce TimestampField, from Str, via {
-    { enabled => 1, path => $_, store => 1 };
+    { enabled => 1, path => $_ };
 };
 coerce TimestampField, from HashRef, via {
     { enabled => 1, %$_ };

--- a/lib/ElasticSearchX/Model/Role.pm
+++ b/lib/ElasticSearchX/Model/Role.pm
@@ -38,7 +38,6 @@ sub deploy {
             );
         };
         sleep(1);
-
         while ( my ( $k, $v ) = each %$mapping ) {
             $t->perform_request(
                 {

--- a/t/document/mapping.t
+++ b/t/document/mapping.t
@@ -75,9 +75,6 @@ is_deeply(
                 fields     => {
                     analyzed => {
                         analyzer  => 'standard',
-                        fielddata => {
-                            format => 'disabled',
-                        },
                         index => 'analyzed',
                         store => 'yes',
                         type  => 'string',
@@ -86,7 +83,6 @@ is_deeply(
                         doc_values   => \1,
                         ignore_above => 2048,
                         index        => 'not_analyzed',
-                        store        => 'yes',
                         type         => 'string',
                     },
                 },
@@ -113,14 +109,10 @@ is_deeply(
                         doc_values   => \1,
                         ignore_above => 2048,
                         index        => 'not_analyzed',
-                        store        => 'yes',
                         type         => 'string',
                     },
                     analyzed => {
                         analyzer  => 'lowercase',
-                        fielddata => {
-                            format => 'disabled',
-                        },
                         index       => 'analyzed',
                         store       => 'yes',
                         term_vector => 'with_positions_offsets',
@@ -131,19 +123,16 @@ is_deeply(
             },
             date => {
                 doc_values => \1,
-                store      => 'yes',
                 type       => 'date',
             },
             default => {
                 doc_values   => \1,
                 ignore_above => 2048,
                 index        => 'not_analyzed',
-                store        => 'yes',
                 type         => 'string',
             },
             loc => {
                 doc_values   => \1,
-                ignore_above => 2048,
                 type         => 'geo_point',
             },
             module => {
@@ -154,9 +143,6 @@ is_deeply(
                         fields     => {
                             analyzed => {
                                 analyzer  => 'standard',
-                                fielddata => {
-                                    format => 'disabled',
-                                },
                                 index => 'analyzed',
                                 store => 'yes',
                                 type  => 'string',
@@ -165,7 +151,6 @@ is_deeply(
                                 doc_values   => \1,
                                 ignore_above => 2048,
                                 index        => 'not_analyzed',
-                                store        => 'yes',
                                 type         => 'string',
                             },
                         },
@@ -182,9 +167,6 @@ is_deeply(
                         fields     => {
                             analyzed => {
                                 analyzer  => 'standard',
-                                fielddata => {
-                                    format => 'disabled',
-                                },
                                 index => 'analyzed',
                                 store => 'yes',
                                 type  => 'string',
@@ -193,7 +175,6 @@ is_deeply(
                                 doc_values   => \1,
                                 ignore_above => 2048,
                                 index        => 'not_analyzed',
-                                store        => 'yes',
                                 type         => 'string',
                             },
                         },
@@ -207,21 +188,16 @@ is_deeply(
                 ignore_above   => 2048,
                 include_in_all => \0,
                 index          => 'not_analyzed',
-                store          => 'yes',
                 type           => 'string',
             },
             profile => {
                 dynamic   => \0,
-                fielddata => {
-                    format => 'disabled',
-                },
                 include_in_root => \1,
                 properties      => {
                     id => {
                         doc_values   => \1,
                         ignore_above => 2048,
                         index        => 'not_analyzed',
-                        store        => 'yes',
                         type         => 'string',
                     },
                 },
@@ -229,28 +205,20 @@ is_deeply(
             },
             res => {
                 dynamic   => \0,
-                fielddata => {
-                    format => 'disabled',
-                },
                 properties => {
                     bugtracker => {
                         dynamic   => \0,
-                        fielddata => {
-                            format => 'disabled',
-                        },
                         properties => {
                             mailto => {
                                 doc_values   => \1,
                                 ignore_above => 2048,
                                 index        => 'not_analyzed',
-                                store        => 'yes',
                                 type         => 'string',
                             },
                             web => {
                                 doc_values   => \1,
                                 ignore_above => 2048,
                                 index        => 'not_analyzed',
-                                store        => 'yes',
                                 type         => 'string',
                             },
                         },
@@ -260,14 +228,12 @@ is_deeply(
                         doc_values   => \1,
                         ignore_above => 2048,
                         index        => 'not_analyzed',
-                        store        => 'yes',
                         type         => 'string',
                     },
                     license => {
                         doc_values   => \1,
                         ignore_above => 2048,
                         index        => 'not_analyzed',
-                        store        => 'yes',
                         type         => 'string',
                     },
                 },

--- a/t/document/mapping.t
+++ b/t/document/mapping.t
@@ -72,7 +72,6 @@ is_deeply(
         include_in_root => \1,
         properties      => {
             name => {
-                doc_values => \1,
                 fields     => {
                     analyzed => {
                         analyzer  => 'standard',
@@ -109,7 +108,6 @@ is_deeply(
         },
         properties => {
             abstract => {
-                doc_values => \1,
                 fields     => {
                     abstract => {
                         doc_values   => \1,
@@ -153,7 +151,6 @@ is_deeply(
                 include_in_root => \1,
                 properties      => {
                     name => {
-                        doc_values => \1,
                         fields     => {
                             analyzed => {
                                 analyzer  => 'standard',
@@ -182,7 +179,6 @@ is_deeply(
                 include_in_root => \1,
                 properties      => {
                     name => {
-                        doc_values => \1,
                         fields     => {
                             analyzed => {
                                 analyzer  => 'standard',

--- a/t/document/mapping.t
+++ b/t/document/mapping.t
@@ -75,9 +75,10 @@ is_deeply(
                 fields     => {
                     analyzed => {
                         analyzer  => 'standard',
-                        index => 'analyzed',
-                        store => 'yes',
-                        type  => 'string',
+                        index     => 'analyzed',
+                        store     => 'yes',
+                        type      => 'string',
+                        fielddata => { format => 'disabled' },
                     },
                     name => {
                         doc_values   => \1,
@@ -117,6 +118,7 @@ is_deeply(
                         store       => 'yes',
                         term_vector => 'with_positions_offsets',
                         type        => 'string',
+                        fielddata   => { format => 'disabled' },
                     },
                 },
                 type => 'multi_field',
@@ -146,6 +148,7 @@ is_deeply(
                                 index => 'analyzed',
                                 store => 'yes',
                                 type  => 'string',
+                                fielddata => { format => 'disabled' },
                             },
                             name => {
                                 doc_values   => \1,
@@ -170,6 +173,7 @@ is_deeply(
                                 index => 'analyzed',
                                 store => 'yes',
                                 type  => 'string',
+                                fielddata   => { format => 'disabled' },
                             },
                             name => {
                                 doc_values   => \1,

--- a/t/es/delete.t
+++ b/t/es/delete.t
@@ -33,6 +33,7 @@ $twitter->index->refresh;
 is( $twitter->count, 15, '15 created' );
 
 ok( $twitter->filter( { term => { name => 'mo' } } )->delete, 'run delete' );
+sleep 5; # wait for delete action to finish
 
 is( $twitter->filter( { term => { name => 'mo' } } )->count,
     0, 'none remain' );

--- a/t/es/version.t
+++ b/t/es/version.t
@@ -38,13 +38,16 @@ throws_ok { $version1->update } qr/Conflict/;
             warn @_;
         }
     };
-    ok( $version1->update( { version => undef } ), 'unset version' );
+    ok( $version1->update( { version_type => "force", version => undef } ), 'unset version' );
 }
 
 throws_ok { $version1->update( { version => $version1->_version - 1 } ) }
-qr/Conflict/;
+qr/illegal version value \[\-1\]/;
 
-ok( $version1->update( { version => $version1->_version } ),
+# shouldn't the correct version be 2 ? (it's currently 0 and being forced to 0 again)
+# we can alternatively do { version_type => "force", version => 2 }
+# -- Mickey
+ok( $version1->update( { version_type => "force", version => $version1->_version } ),
     'set correct version' );
 
 throws_ok { $version1->create } qr/Conflict/;

--- a/t/lib/MyModel.pm
+++ b/t/lib/MyModel.pm
@@ -30,7 +30,6 @@ sub testing {
     if ( $model->es_version < 1 ) {
         plan skip_all => 'Requires Elasticsearch 1.0.0';
     }
-
     ok( $model->deploy( delete => 1 ), 'Deploy ok' );
     return $model;
 }

--- a/t/tutorial.t
+++ b/t/tutorial.t
@@ -117,7 +117,7 @@ is(
 {
 
     package main;
-    my $model = MyModel::Reindex->new( es => $ENV{ES} || ':9200' );
+    my $model = MyModel::Reindex->new( es => $ENV{ES} || ':9900' );
     $model->deploy( delete => 1 );
     my $old = $model->index('twitter');
     my $new = $model->index('twitter_v2');


### PR DESCRIPTION
Since `delete_by_query` is no longer supported,
this change is to use the query to first find all ids
and then issue a bulk `delete_ids` request.

Note: 

It's just a suggestion, something to think of moving forward with the removal of `delete_by_query`.

I'm not sure the return is correct and I don't like the need to delay in the test (we can maybe make use of the callbacks of bulk), but it helps `t/es/delete.t` pass with `ES 1.7.5` and `Search::Elasticsearch 2.00`